### PR TITLE
Fixed inability to read newer worlds due to leveldb changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "library/src/main/jni/leveldb"]
 	path = library/src/main/jni/leveldb
-	url = https://github.com/protolambda/leveldb-mcpe.git
+	url = https://github.com/Mojang/leveldb-mcpe.git

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -16,6 +16,7 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+        opensource {}
     }
 
     sourceSets.main {

--- a/library/src/main/jni/Android.mk
+++ b/library/src/main/jni/Android.mk
@@ -1,7 +1,6 @@
 LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
-
 LOCAL_MODULE := leveldbjni
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/leveldb/include
 LOCAL_CPP_EXTENSION := .cc
@@ -19,6 +18,6 @@ LOCAL_MODULE := leveldb
 LOCAL_CFLAGS := -O3 -D_REENTRANT -DOS_ANDROID -DLEVELDB_PLATFORM_POSIX -DNDEBUG -std=gnu++11 -DDLLX=
 LOCAL_CPP_EXTENSION := .cc
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/leveldb $(LOCAL_PATH)/leveldb/include $(LOCAL_PATH)/leveldb/include/leveldb
-LOCAL_SRC_FILES := leveldb/db/builder.cc leveldb/db/c.cc leveldb/db/dbformat.cc leveldb/db/db_impl.cc leveldb/db/db_iter.cc leveldb/db/dumpfile.cc leveldb/db/filename.cc leveldb/db/log_reader.cc leveldb/db/log_writer.cc leveldb/db/memtable.cc leveldb/db/repair.cc leveldb/db/table_cache.cc leveldb/db/version_edit.cc leveldb/db/version_set.cc leveldb/db/write_batch.cc leveldb/db/zlib_compressor.cc leveldb/table/block_builder.cc leveldb/table/block.cc leveldb/table/filter_block.cc leveldb/table/format.cc leveldb/table/iterator.cc leveldb/table/merger.cc leveldb/table/table_builder.cc leveldb/table/table.cc leveldb/table/two_level_iterator.cc leveldb/util/arena.cc leveldb/util/bloom.cc leveldb/util/cache.cc leveldb/util/coding.cc leveldb/util/comparator.cc leveldb/util/crc32c.cc leveldb/util/env_boost.cc leveldb/util/env.cc leveldb/util/env_posix.cc leveldb/util/env_win.cc leveldb/util/filter_policy.cc leveldb/util/hash.cc leveldb/util/histogram.cc leveldb/util/logging.cc leveldb/util/options.cc leveldb/util/status.cc leveldb/util/win_logger.cc leveldb/port/port_posix.cc
+LOCAL_SRC_FILES := leveldb/db/builder.cc leveldb/db/c.cc leveldb/db/dbformat.cc leveldb/db/db_impl.cc leveldb/db/db_iter.cc leveldb/db/dumpfile.cc leveldb/db/filename.cc leveldb/db/log_reader.cc leveldb/db/log_writer.cc leveldb/db/memtable.cc leveldb/db/repair.cc leveldb/db/table_cache.cc leveldb/db/version_edit.cc leveldb/db/version_set.cc leveldb/db/write_batch.cc leveldb/db/zlib_compressor.cc leveldb/table/block_builder.cc leveldb/table/block.cc leveldb/table/filter_block.cc leveldb/table/format.cc leveldb/table/iterator.cc leveldb/table/merger.cc leveldb/table/table_builder.cc leveldb/table/table.cc leveldb/table/two_level_iterator.cc leveldb/util/arena.cc leveldb/util/bloom.cc leveldb/util/cache.cc leveldb/util/coding.cc leveldb/util/comparator.cc leveldb/util/crc32c.cc leveldb/util/env_boost.cc leveldb/util/env.cc leveldb/util/env_posix.cc leveldb/util/env_win.cc leveldb/util/filter_policy.cc leveldb/util/hash.cc leveldb/util/histogram.cc leveldb/util/logging.cc leveldb/util/options.cc leveldb/util/status.cc leveldb/util/win_logger.cc leveldb/port/port_posix.cc leveldb/port/port_posix_sse.cc
 
 include $(BUILD_STATIC_LIBRARY)

--- a/library/src/main/jni/Application.mk
+++ b/library/src/main/jni/Application.mk
@@ -1,3 +1,3 @@
 APP_PLATFORM=android-16
-APP_ABI := armeabi-v7a x86 x86_64 arm64-v8a mips
+APP_ABI := armeabi-v7a x86 x86_64 arm64-v8a
 APP_STL := c++_static

--- a/library/src/main/jni/com_litl_leveldb_DB.cc
+++ b/library/src/main/jni/com_litl_leveldb_DB.cc
@@ -10,6 +10,11 @@
 #include "leveldb/db.h"
 #include "leveldb/write_batch.h"
 #include "leveldb/zlib_compressor.h"
+#include "leveldb/filter_policy.h"
+#include "leveldb/cache.h"
+#include "leveldb/options.h"
+#include "leveldb/decompress_allocator.h"
+#include "leveldb/env.h"
 
 static jmethodID gByteBuffer_isDirectMethodID;
 static jmethodID gByteBuffer_positionMethodID;
@@ -17,6 +22,12 @@ static jmethodID gByteBuffer_limitMethodID;
 static jmethodID gByteBuffer_arrayMethodID;
 
 static leveldb::ZlibCompressor* zlibCompressorInstance;
+
+class NullLogger : public leveldb::Logger {
+	public:
+		void Logv(const char*, va_list) override {
+		}
+	};
 
 static jlong
 nativeOpen(JNIEnv* env,
@@ -48,7 +59,23 @@ nativeOpen(JNIEnv* env,
     if (zlibCompressorInstance == NULL) {
         zlibCompressorInstance = new leveldb::ZlibCompressor();
     }
-    options.compressors[0] = zlibCompressorInstance;
+
+	//create a bloom filter to quickly tell if a key is in the database or not
+	options.filter_policy = leveldb::NewBloomFilterPolicy(10);
+
+	//create a 40 mb cache (we use this on ~1gb devices)
+	options.block_cache = leveldb::NewLRUCache(40 * 1024 * 1024);
+
+	//create a 4mb write buffer, to improve compression and touch the disk less
+	options.write_buffer_size = 4 * 1024 * 1024;
+
+	//disable internal logging. The default logger will still print out things to a file
+	options.info_log = new NullLogger();
+
+	//use the new raw-zip compressor to write (and read)
+	options.compressors[0] = new leveldb::ZlibCompressorRaw(-1);
+
+    options.compressors[1] = zlibCompressorInstance;
     leveldb::Status status = leveldb::DB::Open(options, path, &db);
     env->ReleaseStringUTFChars(dbpath, path);
 
@@ -83,6 +110,7 @@ nativeGet(JNIEnv * env,
 {
     leveldb::DB* db = reinterpret_cast<leveldb::DB*>(dbPtr);
     leveldb::ReadOptions options = leveldb::ReadOptions();
+	options.decompress_allocator = new leveldb::DecompressAllocator();
     options.snapshot = reinterpret_cast<leveldb::Snapshot*>(snapshotPtr);
 
     size_t keyLen = env->GetArrayLength(keyObj);


### PR DESCRIPTION
A while back Mojang altered the way leveldb files are stored. The protolambda/leveldb_mcpe C++ library used by android-leveldb no longer works with the newer worlds. Mojang released a new version that does work. I've updated the project reference to use the Mojang version, and made changes to the build files and the JNI functions to account for the changes made in the Mojang version.

FYI, if you do pull my changes, you may want to hold off on publishing them to Google Play. I plan on making some additional changes to Blocktopograph itself to support the newer block types, such as concrete and glazed terracotta.